### PR TITLE
Sram Optimization & Slight 7-Segment Changes

### DIFF
--- a/src/tower_arduino_ide/SevSeg.h
+++ b/src/tower_arduino_ide/SevSeg.h
@@ -20,6 +20,7 @@ void start_SevSeg ();//function that runs at the beginning. this sets up the dis
 void refresh_SevSeg();
 void setNewNum_SevSeg (uint8_t);//sets desired integer
 uint8_t convert_state_to_segment(actuator_state_t current_state);
+void set_sevseg_lost_conn(bool new_value);
 
 #ifdef __cplusplus
 }

--- a/src/tower_arduino_ide/radio_comms.cpp
+++ b/src/tower_arduino_ide/radio_comms.cpp
@@ -2,18 +2,18 @@
 #include "Arduino.h"
 #include "serialization_lib/wrt_sdl.h"
 
-// Tower specific things
+// Chose one of 4 Arduino mega UART ports to be used with XBee
 #define XBEE_INTERFACE Serial2
 #include "tower_globals.h"
 
-const unsigned long millis_between_state_req = 200;
-const unsigned long millis_between_daq_req = 1000;
-const unsigned long millis_between_state_push = 200;
-const unsigned long millis_between_client_ack = 200;
-const unsigned long millis_between_client_nack = 200;
-const unsigned long millis_between_tower_ack_req = 200;
-const unsigned long millis_between_tower_send_state = 200;
-const unsigned long millis_between_tower_send_daq = 1000;
+PROGMEM const unsigned long millis_between_state_req = 200;
+PROGMEM const unsigned long millis_between_daq_req = 1000;
+PROGMEM const unsigned long millis_between_state_push = 200;
+PROGMEM const unsigned long millis_between_client_ack = 200;
+PROGMEM const unsigned long millis_between_client_nack = 200;
+PROGMEM const unsigned long millis_between_tower_ack_req = 200;
+PROGMEM const unsigned long millis_between_tower_send_state = 200;
+PROGMEM const unsigned long millis_between_tower_send_daq = 1000;
 
 void radio_init(){
     while(!XBEE_INTERFACE);

--- a/src/tower_arduino_ide/sd_handler.cpp
+++ b/src/tower_arduino_ide/sd_handler.cpp
@@ -5,7 +5,7 @@
 
 //remember kids, always do development in 4K
 //TODO: Main culprit for SRAM optimization
-#define SD_BUFFER_SIZE 4096
+#define SD_BUFFER_SIZE 2048
 
 //#define SD_SERIAL_LOG
 

--- a/src/tower_arduino_ide/sd_handler.cpp
+++ b/src/tower_arduino_ide/sd_handler.cpp
@@ -4,6 +4,7 @@
 #include <SD.h>
 
 //remember kids, always do development in 4K
+//TODO: Main culprit for SRAM optimization
 #define SD_BUFFER_SIZE 4096
 
 //#define SD_SERIAL_LOG

--- a/src/tower_arduino_ide/shared_types.h
+++ b/src/tower_arduino_ide/shared_types.h
@@ -30,6 +30,7 @@ typedef enum {
     DAQ_VALVE_ILLEGAL
 } valve_state_t;
 
+// 48 bytes
 typedef struct {
     uint16_t pressure1; //fill tank pressure
     uint16_t pressure2; //fill line pressure

--- a/src/tower_arduino_ide/tower_arduino_ide.ino
+++ b/src/tower_arduino_ide/tower_arduino_ide.ino
@@ -4,7 +4,6 @@
  *  
  */
 
-
 #include "tower_pin_defines.h"
 #include "tower_fsm.h"
 #include "tower_globals.h"
@@ -18,6 +17,17 @@
 #include "linac.h"
 #include "i2c.h"
 
+// Current state of serial libraries
+// Changed buffer to 16 bits
+// Disabled Serial1
+/*
+// Disable serial ports we don't use (3 and 4) (Reference HardwareSerial.h)
+#undef UBRR2H
+#undef UBRR3H
+// We only send single characters through wire, except for debugging.  
+#define SERIAL_TX_BUFFER_SIZE 10
+#define SERIAL_RX_BUFFER_SIZE 10
+*/
 void setup() {
     //initialize all outputs
     key_switch_init();
@@ -43,10 +53,12 @@ const unsigned long global_min_time_between_contacts = 10000;
 //used for the SD card handler
 extern unsigned long global_time_last_output_flush;
 //flush the rlcslog to sd card every 10 seconds
-extern const unsigned long global_output_flush_interval;
+extern PROGMEM const unsigned long global_output_flush_interval;
 
+/* Disable DAQ for SF6
 extern unsigned long global_time_last_logged_daq;
-extern const unsigned long global_time_between_daq_logs;
+extern PROGMEM const unsigned long global_time_between_daq_logs;
+*/
 
 uint8_t to_put_on_sevenseg = 0b00000000;
 
@@ -56,6 +68,8 @@ void loop() {
         //update FSM, which will deal with command processing
         push_radio_char(xbee_get_byte());
     }
+    // --- disable DAQ for SF6 ---
+    /*
     //get all the daq updates
     read_daq_pins();
     //if we haven't calculated (and thus logged) the daq values in some
@@ -63,6 +77,7 @@ void loop() {
     if (millis() - global_time_last_logged_daq > global_time_between_daq_logs) {
         get_global_current_daq();
     }
+    */
 
     //check time last contact
     if (millis_offset() - time_last_contact > global_min_time_between_contacts) {
@@ -77,7 +92,6 @@ void loop() {
     nio_refresh();
 
     //deal with linear actuator
-
     linac_refresh();
 
     //TODO: If the state us unknown change the display to 'UU'
@@ -86,8 +100,10 @@ void loop() {
     setNewNum_SevSeg(to_put_on_sevenseg);
     refresh_SevSeg();
 
+    /* Disable SD Card for SF6
     //check how long it's been since we flushed the log
     if(millis() - global_time_last_output_flush > global_output_flush_interval){
         flush();
     }
+    */
 }


### PR DESCRIPTION
SOME CHANGES UNTESTED, leaving as draft pr. Once changes have been tested, will be ready for review.

**Changelog**
- 7-segment now displays 'UU' when connection is lost to client-side, as opposed to the current state of acuators
- Many constants in `radio_comms` have been moved to flash memory with the `PROGMEM` attribute
- DAQ has been disabled for SF6 as it is not run through tower-side for static fires
- SD card has been disabled for SF6 to reflect its in-progress state
- SD card buffer has been halved to reduce SRAM usage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/rlcs/34)
<!-- Reviewable:end -->
