### PR TITLE
Make clientside switches consistently reflect actuator states

### DIFF
--- a/src/clientside/clientside.ino
+++ b/src/clientside/clientside.ino
@@ -1,3 +1,4 @@
+#include "common/config.cpp" // cursed subfolder compile
 #include "common/communication.hpp"
 #include "config.hpp"
 #include "hardware.hpp"
@@ -11,24 +12,26 @@ void setup() {
   Serial.begin(115200); // USB connection
   Serial3.begin(9600);  // Towerside connection
 
-  Communicator<ActuatorMessage, SensorMessage> communicator{
+  Communicator<ActuatorMessage, SensorMessage> towerside_communicator{
       Serial3, config::COMMUNICATION_RESET_MS};
+  Communicator<config::USBMessage, int> usb_communicator{
+      Serial, config::COMMUNICATION_RESET_MS};
   unsigned long last_sent_time = 0;
-  ActuatorMessage last_switch_positions = config::build_default_message();
+  ActuatorMessage last_switch_positions = build_safe_state(ActuatorMessage());
+  SensorMessage last_sensor_msg;
 
   hardware::set_status_disconnected();
   // Avoid the status showing as connected for the first few seconds on
   // startup if we aren't really
   bool any_messages_received = false;
   while (true) {
-    communicator.read_byte();
-    SensorMessage msg;
-    if (communicator.get_message(&msg)) {
+    towerside_communicator.read_byte();
+    if (towerside_communicator.get_message(&last_sensor_msg)) {
       any_messages_received = true;
-      lcd::update(msg);
+      lcd::update(last_sensor_msg);
     }
 
-    bool has_contact = communicator.seconds_since_last_contact() <
+    bool has_contact = towerside_communicator.seconds_since_last_contact() <
                        config::COMMUNICATION_TIMEOUT_S;
     if (has_contact && any_messages_received) {
       hardware::set_status_connected();
@@ -45,7 +48,12 @@ void setup() {
     if ((millis() > last_sent_time + config::COMMAND_MESSAGE_INTERVAL_MS)) {
       // condition: passed COMMAND_MESSAGE_INTERVAL_MS since last time sent message
       last_sent_time = millis();
-      communicator.send(last_switch_positions);
+      towerside_communicator.send(last_switch_positions);
+
+      usb_communicator.send(config::USBMessage{
+        .actuator_msg = last_switch_positions,
+        .sensor_msg = last_sensor_msg
+      });
     }
   }
 }

--- a/src/clientside/config.cpp
+++ b/src/clientside/config.cpp
@@ -24,18 +24,4 @@ ActuatorMessage build_command_message() {
   };
 }
 
-ActuatorMessage build_default_message() {
-  return ActuatorMessage{
-      .valve_1 = false,
-      .valve_2 = false,
-      .valve_3 = false,
-      .valve_4 = false,
-      //.injector_valve = false,
-      .ignition_primary = false,
-      .ignition_secondary = false,
-      .rocket_power = false,
-      .fill_disconnect = false,
-  };
-}
-
 } // namespace config

--- a/src/clientside/config.hpp
+++ b/src/clientside/config.hpp
@@ -7,7 +7,6 @@
 namespace config {
 
 ActuatorMessage build_command_message();
-ActuatorMessage build_default_message();
 
 constexpr unsigned long COMMAND_MESSAGE_INTERVAL_MS = 100;
 constexpr unsigned long COMMUNICATION_RESET_MS = 50;
@@ -16,6 +15,14 @@ constexpr uint16_t COMMUNICATION_TIMEOUT_S = 3;
 constexpr uint16_t BATT_SCALE_PRE_OFFSET = -11;
 constexpr uint16_t BATT_SCALE_NUM = 1;
 constexpr uint16_t BATT_SCALE_DEN = 7;
+
+; // random semicolon to fix clangd warning bug, see: https://stackoverflow.com/questions/72456118/why-does-clang-give-a-warning-unterminated-pragma-pack-push-at-end-of-f
+#pragma pack(push, 1)
+struct USBMessage {
+  ActuatorMessage actuator_msg;
+  SensorMessage sensor_msg;
+};
+#pragma pack(pop)
 
 } // namespace config
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -1,0 +1,16 @@
+#include "config.hpp"
+
+ActuatorMessage build_safe_state(const ActuatorMessage &current_state) {
+  return ActuatorMessage{
+      .valve_1 = false,
+      .valve_2 = true,
+      .valve_3 = false,
+      .valve_4 = true,
+      //.injector_valve = current_state.injector_valve,
+      .ignition_primary = false,
+      .ignition_secondary = false,
+      .rocket_power = false,
+      .fill_disconnect = false,
+  };
+}
+

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -36,6 +36,8 @@ struct ActuatorMessage {
   }
 };
 
+ActuatorMessage build_safe_state(const ActuatorMessage &current_state);
+
 struct SensorMessage {
   // Battery Voltages
   uint16_t towerside_main_batt_mv;

--- a/src/towerside/config.cpp
+++ b/src/towerside/config.cpp
@@ -19,28 +19,14 @@ struct Actuators {
 
 void apply(const ActuatorMessage &command) {
   ACTUATORS.valve_1.set(command.valve_1);
-  ACTUATORS.valve_2.set(!command.valve_2);
+  ACTUATORS.valve_2.set(command.valve_2);
   ACTUATORS.valve_3.set(command.valve_3);
-  ACTUATORS.valve_4.set(command.valve_4);
+  ACTUATORS.valve_4.set(!command.valve_4); // inverted solenoid
   //ACTUATORS.injector_valve.set(command.injector_valve);
   ACTUATORS.ignition_primary.set(command.ignition_primary);
   ACTUATORS.ignition_secondary.set(command.ignition_primary); // fire both ignitions in response to ignition_primary
   ACTUATORS.fill_disconnect.set(command.fill_disconnect);
-  ACTUATORS.rocket_power.set(!command.rocket_power); // the firmware inverts the command, so un-invert it ("vert" it) here
-}
-
-ActuatorMessage build_safe_state(const ActuatorMessage &current_state) {
-  return ActuatorMessage{
-      .valve_1 = false,
-      .valve_2 = false,
-      .valve_3 = false,
-      .valve_4 = false,
-      //.injector_valve = current_state.injector_valve,
-      .ignition_primary = false,
-      .ignition_secondary = false,
-      .rocket_power = false,
-      .fill_disconnect = false,
-  };
+  ACTUATORS.rocket_power.set(!command.rocket_power); // the firmware inverts the command, so un-invert it here
 }
 
 SensorMessage build_sensor_message() {

--- a/src/towerside/config.hpp
+++ b/src/towerside/config.hpp
@@ -8,7 +8,6 @@
 namespace config {
 
 void apply(const ActuatorMessage &command);
-ActuatorMessage build_safe_state(const ActuatorMessage &current_state);
 SensorMessage build_sensor_message();
 
 constexpr uint16_t COMMUNICATION_TIMEOUT_S = 10; // Go to safe state after this many seconds without contact

--- a/src/towerside/towerside.ino
+++ b/src/towerside/towerside.ino
@@ -1,3 +1,4 @@
+#include "common/config.cpp" // cursed subfolder compile
 #include "common/communication.hpp"
 #include "config.hpp"
 #include "pinout.hpp"
@@ -21,7 +22,7 @@ void setup() {
   Communicator<SensorMessage, ActuatorMessage> communicator {Serial2, config::COMMUNICATION_RESET_MS};
   unsigned long last_sensor_msg_time = 0;
   // The current towerside state. Each tick we command all actuators to take the action specified by it
-  ActuatorMessage current_cmd = config::build_safe_state(ActuatorMessage());
+  ActuatorMessage current_cmd = build_safe_state(ActuatorMessage());
   ActuatorMessage last_cmd; // The last received message from clientside, used for error detection
   
   // We loop here so that the variables defined above are in scope
@@ -43,7 +44,7 @@ void setup() {
     digitalWrite(pinout::ARM_STATUS_LED,sensors::is_armed());
     if (!has_contact) {
       // Override clientside's command and go to safe state
-      current_cmd = config::build_safe_state(current_cmd);
+      current_cmd = build_safe_state(current_cmd);
     }
 
     config::apply(current_cmd);


### PR DESCRIPTION
Note that I'm going to add switches to control vent and injector valves along with remote arming in this PR later on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/rlcs/45)
<!-- Reviewable:end -->
